### PR TITLE
narrowed down event index results

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -3,7 +3,8 @@
   before_action :set_event, only: [:show, :update, :edit, :destroy]
 
   def index
-    @events = Event.all
+    # @events = Event.all
+    @events = Event.upcoming.events_near_me(current_user.profile)
   end
 
   def show
@@ -13,6 +14,7 @@
     # @attendance = @attendance.event.profile #to be tested - not sure about syntax
 
     # create empty Attendance object to be filled
+
 
     @hash = Gmaps4rails.build_markers(@event) do |address, marker|
       marker.lat address.latitude
@@ -49,9 +51,6 @@
       render :new
 #     to be confirmed
     end
-  end
-
-  def edit
   end
 
   def update

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,4 +1,6 @@
 class Event < ApplicationRecord
+  scope :upcoming, -> { where("start_date >= ?", Date.today) }
+
   belongs_to :profile
   has_many :attendances, dependent: :destroy
   validates :start_date, presence: true
@@ -11,6 +13,10 @@ class Event < ApplicationRecord
 
   geocoded_by :full_address
   after_validation :geocode, if: :street_name_changed?
+
+  def self.events_near_me(profile)
+    self.near([profile.latitude, profile.longitude], 5, units: :km,  order: "start_date ASC, distance ASC")
+  end
 
   def full_address
     "#{street_name}, #{zipcode}, #{city} #{country}"
@@ -27,6 +33,7 @@ class Event < ApplicationRecord
     return false
   end
 
+end
 
   # def formatted_duration(total_minute)
   #   hours = total_minute / 60
@@ -34,4 +41,4 @@ class Event < ApplicationRecord
   #   "#{ hours }h #{ minutes }min"
   # end
 
-end
+

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -23,6 +23,6 @@ class Profile < ApplicationRecord
   end
 
   def profiles_near_me
-    profiles = Profile.near([self.latitude, self.longitude], 5, units: :km).where.not(id: self.id)
+    profiles = Profile.near([self.latitude, self.longitude], 5, units: :km, :order => false).where.not(id: self.id)
   end
 end

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -1,7 +1,4 @@
 <% content_for :title, "#{@event.description}" %>
 
-<h1>Events#edit</h1>
-<p>Find me in app/views/events/edit.html.erb</p>
-
 <h1>Update event</h1>
 <%= render 'form' %>


### PR DESCRIPTION
On the index page for events we now only show events that are taking place today or in the future and by distance. If there's multiple events in the same day it'll order  by distance in ascending order. 